### PR TITLE
gather stats from zookeeper mntr command

### DIFF
--- a/checks.d/zk.py
+++ b/checks.d/zk.py
@@ -1,14 +1,21 @@
 '''
-As of ZooKeeper 3.4.0, the `mntr` admin command is provided for easy parsing of ZooKeeper stats.
-This check first parses the `stat` command for a version number.
-If the version supports `mntr`, `mntr` is also parsed.
+As of zookeeper 3.4.0, the `mntr` admin command is provided for easy parsing of zookeeper stats.
+This check first parses the `stat` admin command for a version number.
+If the zookeeper version supports `mntr`, it is also parsed.
 
 Duplicate information is being reported by both `mntr` and `stat` to keep backwards compatability.
 Example:
     `stat` reports: zookeeper.latency.avg
     `mntr` reports: zookeeper.avg.latency
-You should make use of the stat reported by `mntr`.
-The `stat` name is only kept for backward compatability reasons.
+If available, make use of the data reported by `mntr` not `stat`.
+The dublicate `stat` reports are only kept for backward compatability.
+
+Besides the usual zookeeper state of `leader`, `follower`, `observer` amd `standalone`,
+this check will report three other states:
+
+    `down`: the check cannot connect to zookeeper
+    `inactive`: the zookeeper instance has lost connection to the cluster
+    `unknown`: an unexpected error has occured in this check
 
 Parses the response from zookeeper's `stat` admin command, which looks like:
 
@@ -35,7 +42,7 @@ Node count: 487
 
 The following is an example of the `mntr` commands output:
 
-````
+```
 zk_version  3.4.5-cdh4.4.0--1, built on 09/04/2013 01:46 GMT
 zk_avg_latency  0
 zk_max_latency  0
@@ -51,23 +58,7 @@ zk_ephemerals_count 0
 zk_approximate_data_size    27
 zk_open_file_descriptor_count   29
 zk_max_file_descriptor_count    4096
-````
-
-ZooKeeper `mntr` command may also output the following error:
-
-````
-This ZooKeeper instance is not currently serving requests
-````
-
-Stats parsed from `mntr` are reported with the given name
-where 'zk' is replaced with 'zookeeper' and '_' is replaced with '.'
-example: 'zk_avg_latency' becomes 'zookeeper.avg.latency'
-
-The state of ZooKeeper is reported with the tag 'mode:{inactive,leader,standalone,follower,observer,unknown,down}'
-'inactive' state is reported when `mntr` reports error.
-`down` state is reported when zookeeper is unreachable.
-`unknown` state is reported when any other exception occurs in this Check.
-State and hostname are also reported through the set 'zookeeper.instances'
+```
 
 `mntr` tested with ZooKeeper 3.4.5
 '''

--- a/checks.d/zk.py
+++ b/checks.d/zk.py
@@ -10,12 +10,15 @@ Example:
 If available, make use of the data reported by `mntr` not `stat`.
 The dublicate `stat` reports are only kept for backward compatability.
 
-Besides the usual zookeeper state of `leader`, `follower`, `observer` amd `standalone`,
+Besides the usual zookeeper state of `leader`, `follower`, `observer` and `standalone`,
 this check will report three other states:
 
     `down`: the check cannot connect to zookeeper
     `inactive`: the zookeeper instance has lost connection to the cluster
     `unknown`: an unexpected error has occured in this check
+
+States can be accessed through the gauge `zookeeper.instances.<state>,
+through the set `zookeeper.instances`, or through the `mode:<state>` tag.
 
 Parses the response from zookeeper's `stat` admin command, which looks like:
 

--- a/checks.d/zk.py
+++ b/checks.d/zk.py
@@ -1,4 +1,15 @@
 '''
+As of ZooKeeper 3.4.0, the `mntr` admin command is provided for easy parsing of ZooKeeper stats.
+This check first parses the `stat` command for a version number.
+If the version supports `mntr`, `mntr` is also parsed.
+
+Duplicate information is being reported by both `mntr` and `stat` to keep backwards compatability.
+Example:
+    `stat` reports: zookeeper.latency.avg
+    `mntr` reports: zookeeper.avg.latency
+You should make use of the stat reported by `mntr`.
+The `stat` name is only kept for backward compatability reasons.
+
 Parses the response from zookeeper's `stat` admin command, which looks like:
 
 ```
@@ -20,14 +31,53 @@ Mode: leader
 Node count: 487
 ```
 
-Tested with Zookeeper versions 3.0.0 to 3.4.5
+`stat` tested with Zookeeper versions 3.0.0 to 3.4.5
 
+The following is an example of the `mntr` commands output:
+
+````
+zk_version  3.4.5-cdh4.4.0--1, built on 09/04/2013 01:46 GMT
+zk_avg_latency  0
+zk_max_latency  0
+zk_min_latency  0
+zk_packets_received 4
+zk_packets_sent 3
+zk_num_alive_connections    1
+zk_outstanding_requests 0
+zk_server_state standalone
+zk_znode_count  4
+zk_watch_count  0
+zk_ephemerals_count 0
+zk_approximate_data_size    27
+zk_open_file_descriptor_count   29
+zk_max_file_descriptor_count    4096
+````
+
+ZooKeeper `mntr` command may also output the following error:
+
+````
+This ZooKeeper instance is not currently serving requests
+````
+
+Stats parsed from `mntr` are reported with the given name
+where 'zk' is replaced with 'zookeeper' and '_' is replaced with '.'
+example: 'zk_avg_latency' becomes 'zookeeper.avg.latency'
+
+The state of ZooKeeper is reported with the tag 'mode:{inactive,leader,standalone,follower,observer,unknown,down}'
+'inactive' state is reported when `mntr` reports error.
+`down` state is reported when zookeeper is unreachable.
+`unknown` state is reported when any other exception occurs in this Check.
+State and hostname are also reported through the set 'zookeeper.instances'
+
+`mntr` tested with ZooKeeper 3.4.5
 '''
 # stdlib
 import re
 import socket
+import sys
 from StringIO import StringIO
 import struct
+from distutils.version import LooseVersion
 
 # project
 from checks import AgentCheck
@@ -51,6 +101,9 @@ class ZookeeperCheck(AgentCheck):
         tags = instance.get('tags', [])
         cx_args = (host, port, timeout)
         sc_tags = ["host:{0}".format(host), "port:{0}".format(port)]
+        hostname = socket.gethostname()
+
+        zk_version = None # parse_stat will parse and set version string
 
         # Send a service check based on the `ruok` response.
         try:
@@ -76,14 +129,22 @@ class ZookeeperCheck(AgentCheck):
             stat_out = self._send_command('stat', *cx_args)
         except ZKConnectionFailure:
             self.increment('zookeeper.timeouts')
-            raise
+            self.set_instance_status(hostname, 'down')
+        except:
+            e = sys.exc_info()[1]
+            print >> sys.stderr, "Error: %s" % e
+            self.increment('zookeeper.datadog_client_exception')
+            self.set_instance_status(hostname, 'unknown')
         else:
             # Parse the response
-            metrics, new_tags, mode = self.parse_stat(stat_out)
+            metrics, new_tags, state, zk_version = self.parse_stat(stat_out)
+            mode = "mode:%s" % state
 
             # Write the data
-            for metric, value in metrics:
-                self.gauge(metric, value, tags=tags + new_tags)
+            if state != 'inactive':
+                for metric, value in metrics:
+                    self.gauge(metric, value, tags=tags + new_tags)
+            self.set_instance_status(hostname, state)
 
             if expected_mode:
                 if mode == expected_mode:
@@ -95,6 +156,47 @@ class ZookeeperCheck(AgentCheck):
                               % (mode, expected_mode)
                 self.service_check('zookeeper.mode', status, message=message,
                                    tags=sc_tags)
+
+        if zk_version and LooseVersion(zk_version) > LooseVersion("3.4.0"):
+            try:
+                mntr_out = self._send_command('mntr', *cx_args)
+            except ZKConnectionFailure:
+                self.increment('zookeeper.timeouts')
+            except:
+                e = sys.exc_info()[1]
+                print >> sys.stderr, "Error: %s" % e
+                self.increment('zookeeper.datadog_client_exception')
+            else:
+                metrics, state = self.parse_mntr(mntr_out)
+                mode = "mode:%s" % state
+                if state != 'inactive':
+                    for name in metrics:
+                        self.gauge(name, metrics[name], tags=tags + [mode])
+
+
+    def set_instance_status(self, hostname, status):
+        mode = 'mode:%s' % status
+        tags = [mode]
+        self.set('zookeeper.instances', hostname, tags=tags)
+
+        gauges = {
+            'leader': 0,
+            'follower': 0,
+            'observer': 0,
+            'standalone': 0,
+            'down': 0,
+            'inactive': 0,
+            'unknown': 0
+        }
+
+        if status in gauges.keys():
+            gauges[status] = 1
+        else:
+            gauges['unknown'] = 1
+
+        for k in gauges:
+            gauge_name = 'zookeeper.instances.%s' % k
+            self.gauge(gauge_name, gauges[k])
 
     def _send_command(self, command, host, port, timeout):
         sock = socket.socket()
@@ -127,9 +229,10 @@ class ZookeeperCheck(AgentCheck):
             sock.close()
         return buf
 
+
     def parse_stat(self, buf):
         ''' `buf` is a readable file-like object
-            returns a tuple: ([(metric_name, value)], tags)
+            returns a tuple: (metrics, tags, mode, version)
         '''
         metrics = []
         buf.seek(0)
@@ -140,10 +243,12 @@ class ZookeeperCheck(AgentCheck):
         start_line = buf.readline()
         match = self.version_pattern.match(start_line)
         if match is None:
+            return (None, None, "inactive", None)
             raise Exception("Could not parse version from stat command output: %s" % start_line)
         else:
             version_tuple = match.groups()
         has_connections_val = version_tuple >= ('3', '4', '4')
+        version = "%s.%s.%s" % version_tuple
 
         # Clients:
         buf.readline() # skip the Clients: header
@@ -210,4 +315,34 @@ class ZookeeperCheck(AgentCheck):
         _, value = buf.readline().split(':')
         metrics.append(('zookeeper.nodes', long(value.strip())))
 
-        return metrics, tags, mode
+        return metrics, tags, mode, version
+
+
+    def parse_mntr(self, buf):
+        ''' `buf` is a readable file-like object
+            returns a tuple: (metrics, state)
+            if state == 'inactive', metrics will be None
+        '''
+
+        buf.seek(0)
+        first = buf.readline() # first is version string or error
+        if first == 'This ZooKeeper instance is not currently serving requests':
+            return (None, 'inactive')
+
+        metrics = {}
+
+        for line in buf:
+            data = line.split()
+            if len(data) == 2:
+                name = data[0].replace('zk', 'zookeeper').replace('_', '.')
+                metrics[name] = data[1]
+            else:
+                raise Exception("Data not in 'key value' format, could not parse '%s'" % data.join(' '))
+
+        # state is a string {'standalone', 'leader', 'follower', 'observer'}
+        state = metrics.pop('zookeeper.server.state').lower()
+
+        for key in metrics: # everything else is an int
+            metrics[key] = int(metrics[key])
+
+        return (metrics, state)

--- a/checks.d/zk.py
+++ b/checks.d/zk.py
@@ -113,6 +113,7 @@ class ZookeeperCheck(AgentCheck):
             status = AgentCheck.CRITICAL
             message = 'No response from `ruok` command'
             self.increment('zookeeper.timeouts')
+            raise
         else:
             ruok_out.seek(0)
             ruok = ruok_out.readline()
@@ -121,8 +122,9 @@ class ZookeeperCheck(AgentCheck):
             else:
                 status = AgentCheck.WARNING
             message = u'Response from the server: %s' % ruok
-        self.service_check('zookeeper.ruok', status, message=message,
-                           tags=sc_tags)
+        finally:
+            self.service_check('zookeeper.ruok', status, message=message,
+                    tags=sc_tags)
 
         # Read metrics from the `stat` output.
         try:
@@ -147,7 +149,7 @@ class ZookeeperCheck(AgentCheck):
             self.set_instance_status(hostname, state)
 
             if expected_mode:
-                if mode == expected_mode:
+                if state == expected_mode:
                     status = AgentCheck.OK
                     message = u"Server is in %s mode" % mode
                 else:

--- a/tests/checks/integration/test_zk.py
+++ b/tests/checks/integration/test_zk.py
@@ -27,7 +27,7 @@ class ZooKeeperTestCase(AgentCheckTest):
     CONNECTION_FAILURE_CONFIG = {
         'host': "127.0.0.1",
         'port': 2182,
-        'expected_mode': "follower",
+        'expected_mode': "standalone",
         'tags': []
     }
 

--- a/tests/checks/integration/test_zk.py
+++ b/tests/checks/integration/test_zk.py
@@ -27,7 +27,7 @@ class ZooKeeperTestCase(AgentCheckTest):
     CONNECTION_FAILURE_CONFIG = {
         'host': "127.0.0.1",
         'port': 2182,
-        'expected_mode': "standalone",
+        'expected_mode': "down",
         'tags': []
     }
 
@@ -74,9 +74,10 @@ class ZooKeeperTestCase(AgentCheckTest):
         self.assertServiceCheck("zookeeper.ruok", status=AgentCheck.OK)
         self.assertServiceCheck("zookeeper.mode", status=AgentCheck.OK)
 
+        expected_mode = self.CONFIG['expected_mode']
         for t in self.STATUS_TYPES:
             expected_value = 0
-            if t == 'standalone':
+            if t == expected_mode:
                 expected_value = 1 
             mname = "zookeeper.instances." + t
             self.assertMetric(mname, value=expected_value, count=1)
@@ -113,9 +114,10 @@ class ZooKeeperTestCase(AgentCheckTest):
 
         self.assertMetric("zookeeper.instances", tags=["mode:down"], count=1)
 
+        expected_mode = self.CONNECTION_FAILURE_CONFIG['expected_mode']
         for t in self.STATUS_TYPES:
             expected_value = 0
-            if t == 'down':
+            if t == expected_mode:
                 expected_value = 1 
             mname = "zookeeper.instances." + t
             self.assertMetric(mname, value=expected_value, count=1)

--- a/tests/checks/integration/test_zk.py
+++ b/tests/checks/integration/test_zk.py
@@ -31,7 +31,7 @@ class ZooKeeperTestCase(AgentCheckTest):
         'tags': []
     }
 
-    METRICS = [
+    STAT_METRICS = [
         'zookeeper.latency.min',
         'zookeeper.latency.avg',
         'zookeeper.latency.max',
@@ -44,6 +44,17 @@ class ZooKeeperTestCase(AgentCheckTest):
         'zookeeper.zxid.epoch',
         'zookeeper.zxid.count',
         'zookeeper.nodes',
+        'zookeeper.instances',
+    ]
+
+    STATUS_TYPES = [
+        'leader',
+        'follower',
+        'observer',
+        'standalone',
+        'down',
+        'inactive',
+        'unknown',
     ]
 
     def test_check(self):
@@ -56,12 +67,19 @@ class ZooKeeperTestCase(AgentCheckTest):
         self.run_check(config)
 
         # Test metrics
-        for mname in self.METRICS:
+        for mname in self.STAT_METRICS:
             self.assertMetric(mname, tags=["mode:standalone", "mytag"], count=1)
 
         # Test service checks
         self.assertServiceCheck("zookeeper.ruok", status=AgentCheck.OK)
         self.assertServiceCheck("zookeeper.mode", status=AgentCheck.OK)
+
+        for t in self.STATUS_TYPES:
+            expected_value = 0
+            if t == 'standalone':
+                expected_value = 1 
+            mname = "zookeeper.instances." + t
+            self.assertMetric(mname, value=expected_value, count=1)
 
         self.coverage_report()
 
@@ -79,7 +97,8 @@ class ZooKeeperTestCase(AgentCheckTest):
 
     def test_error_state(self):
         """
-        Raise a 'critical' service check when ZooKeeper is in an error state
+        Raise a 'critical' service check when ZooKeeper is in an error state.
+        Report status as down.
         """
         config = {
             'instances': [self.CONNECTION_FAILURE_CONFIG]
@@ -90,5 +109,14 @@ class ZooKeeperTestCase(AgentCheckTest):
             lambda: self.run_check(config)
         )
 
-        # Test service checks
         self.assertServiceCheck("zookeeper.ruok", status=AgentCheck.CRITICAL)
+
+        self.assertMetric("zookeeper.instances", tags=["mode:down"], count=1)
+
+        for t in self.STATUS_TYPES:
+            expected_value = 0
+            if t == 'down':
+                expected_value = 1 
+            mname = "zookeeper.instances." + t
+            self.assertMetric(mname, value=expected_value, count=1)
+


### PR DESCRIPTION
Zookeeper has a tcp 4 letter command API that reports information worth logging.
Currently only the 'stat' command is being read. This adds 'mntr' command.

I'm trying to follow similar style to the parsing of the 'stat' command. Currently, all the results are reported as gauges with a tag of the given state. (one of 'standalone', 'leader' or 'follower')

I'm having trouble visualizing how this will be displayed in DataDog. I am also concerned with information conflicts between the 'stat' and 'mntr' command.

To test locally:
1. Make sure you have zookeeper running locally on the default port.
2. Setup the dd-agent repo as explained in the readme.
3. Add the following code block to the bottom of the `checks.d/zk.py` file.

``` python
if __name__ == '__main__':
    import json
    check, instances = ZookeeperCheck.from_yaml('/home/vagrant/src/dd-agent/conf.d/zk.yaml.example')
    for instance in instances:
        check.check(instance)
        if check.has_events():
            print(json.dumps(check.get_events(), indent=2, separators=(',',': ')))
        print(json.dumps(check.get_metrics(), indent=2, separators=(',',': ')))
```

4 . While inside the venv (with `. venv/bin/activate`) run the file.

```
PYTHONPATH=. python checks.d/zk.py
```

@Sirupsen @fw42 maybe have a quick glance at this?
